### PR TITLE
Remove handlers

### DIFF
--- a/ata_api/main.py
+++ b/ata_api/main.py
@@ -104,20 +104,4 @@ def get_prescription(site_name: str, user_id: str) -> PrescriptionResponse:
             return PrescriptionResponse(group=Group.C, value=0)
 
 
-@app.get("/prescription/{site_name}")
-def get_prescription_invalid_params(site_name: str) -> None:
-    # test if site exists
-    if site_name not in [*SiteName]:
-        # if it doesn't
-        raise HTTPException(status_code=404, detail=f"Invalid site: {site_name}. You also need to specify a user ID")
-    else:
-        # if site exists, request a user ID
-        raise HTTPException(status_code=404, detail="Please, specify a user ID")
-
-
-@app.get("/prescription/")
-def get_prescription_no_params() -> None:
-    raise HTTPException(status_code=404, detail="Please specify a site and a user ID")
-
-
 handler = Mangum(app)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,22 +5,6 @@ from ata_api.main import app
 client = TestClient(app)
 
 
-def test_dummy_site() -> None:
-    response = client.get("/prescription/dummysite/")
-    assert response.status_code == 404
-    assert response.json() == {
-        "detail": "Invalid site: dummysite. You also need to specify a user ID",
-    }
-
-
-def test_no_user() -> None:
-    response = client.get("/prescription/the-19th/")
-    assert response.status_code == 404
-    assert response.json() == {
-        "detail": "Please, specify a user ID",
-    }
-
-
 def test_invalid_uuid() -> None:
     response = client.get("/prescription/the-19th/dummyuser")
     assert response.status_code == 404
@@ -29,17 +13,9 @@ def test_invalid_uuid() -> None:
     }
 
 
-def test_invalid_user_and_site() -> None:
+def test_invalid_site() -> None:
     response = client.get("/prescription/dummysite/bc9d39e6-bb74-4bbd-8048-b7ac54054982")
     assert response.status_code == 404
     assert response.json() == {
         "detail": "Invalid site: dummysite",
-    }
-
-
-def test_only_prescription() -> None:
-    response = client.get("/prescription/")
-    assert response.status_code == 404
-    assert response.json() == {
-        "detail": "Please specify a site and a user ID",
     }


### PR DESCRIPTION
## Description

They're kind of unnecessary. The UUID and site validators in the main prescription handler are kept, though.