### PR TITLE
Add CORS endpoint tests

### DIFF
--- a/ata_api/cors.py
+++ b/ata_api/cors.py
@@ -1,46 +1,17 @@
-import functools
-from typing import Callable, Union
+from typing import Optional
 
 from fastapi import Response
-from fastapi.encoders import jsonable_encoder
-from fastapi.responses import JSONResponse
-from pydantic import BaseModel
-from typing_extensions import ParamSpec
-
-from ata_api.settings import settings
-
-P = ParamSpec("P")
+from pydantic import HttpUrl
 
 
-def allow_cors(func: Callable[P, Union[BaseModel, Response]]) -> Callable[P, Union[BaseModel, Response]]:
+def evaluate_cors(response: Response, origin: Optional[HttpUrl], cors_allowed_origins: set[HttpUrl]) -> None:
     """
-    Wraps a FastAPI path function to allow CORS requests.
-    Works with or without the FastAPI CORS middleware.
+    Evaluates the origin of a request and updates the response headers accordingly.
     """
-
-    @functools.wraps(func)
-    def wrapper(*args: P.args, **kwargs: P.kwargs) -> Union[BaseModel, Response]:
-        output = func(*args, **kwargs)
-
-        origin = kwargs.get("origin")
-
-        # Still check if origin is allowed in case preflight request is not sent
-        if origin is None or origin not in settings.cors_allowed_origins:
-            return output
-
-        # If output is a BaseModel, return a JSONResponse with CORS headers
-        if isinstance(output, BaseModel):
-            return JSONResponse(
-                headers={
-                    "Access-Control-Allow-Origin": str(origin),
-                    "Vary": "Origin",
-                },
-                content=jsonable_encoder(output),
-            )
-        # If output is a Response, update its headers with CORS headers
-        elif isinstance(output, Response):
-            output.headers["Access-Control-Allow-Origin"] = str(origin)
-            output.headers.add_vary_header("Origin")
-            return output
-
-    return wrapper
+    if origin is not None and origin in cors_allowed_origins:
+        response.headers.update(
+            {
+                "Access-Control-Allow-Origin": str(origin),
+                "Vary": "Origin",
+            }
+        )

--- a/ata_api/main.py
+++ b/ata_api/main.py
@@ -4,45 +4,46 @@ from uuid import UUID
 
 from ata_db_models.models import Group
 from fastapi import Depends, Header, Path, Query, Response
-from fastapi.responses import JSONResponse
 from mangum import Mangum
 from pydantic import HttpUrl
 from sqlalchemy.orm import Session
 
 from ata_api.app import app
-from ata_api.cors import allow_cors
+from ata_api.cors import evaluate_cors
 from ata_api.crud import create_prescription, read_prescription
 from ata_api.db import create_db_session
 from ata_api.models import PrescriptionResponse
 from ata_api.monitoring.logging import logger
 from ata_api.monitoring.metrics import metrics
-from ata_api.settings import settings
+from ata_api.settings import Settings, get_settings
 from ata_api.site import SiteName
 
-logger.info(f"AtA API starting up on stage {settings.stage}")
-
-Origin = Annotated[Union[HttpUrl, None], Header(title="Origin of request")]
+AnnotatedOrigin = Annotated[Union[HttpUrl, None], Header(title="Origin of request")]
+AnnotatedSettings = Annotated[Settings, Depends(get_settings)]
 
 
 @app.get("/")
-@allow_cors
 def get_root(
     response: Response,
-    origin: Origin = None,
-) -> JSONResponse:
-    return JSONResponse(content={"message": "This is the root endpoint for the AtA API."})
+    settings: AnnotatedSettings,
+    origin: AnnotatedOrigin = None,
+) -> dict[str, str]:
+    # Evaluate CORS
+    evaluate_cors(response, origin, settings.cors_allowed_origins)
+
+    return {"message": "This is the root endpoint for the AtA API."}
 
 
 @app.get("/prescription/{site_name}/{user_id}", response_model=PrescriptionResponse)
-@allow_cors
 def get_prescription(
     response: Response,
+    settings: AnnotatedSettings,
     site_name: Annotated[SiteName, Path(title="Site name")],
     user_id: Annotated[UUID, Path(title="Snowplow user ID")],
     wa: Annotated[int, Query(title="Weight of assignment to A", ge=0)] = 1,
     wb: Annotated[int, Query(title="Weight of assignment to B", ge=0)] = 1,
     wc: Annotated[int, Query(title="Weight of assignment to C", ge=0)] = 1,
-    origin: Origin = None,
+    origin: AnnotatedOrigin = None,
     session: Session = Depends(create_db_session),
 ) -> PrescriptionResponse:
     # Get group assignment. If it doesn't exist, create it.
@@ -54,6 +55,9 @@ def get_prescription(
         usergroup = create_prescription(
             session, site_name, user_id, group=random.choices([Group.A, Group.B, Group.C], weights=[wa, wb, wc], k=1)[0]
         )
+
+    # Evaluate CORS
+    evaluate_cors(response, origin, settings.cors_allowed_origins)
 
     return PrescriptionResponse(site_name=usergroup.site_name, user_id=usergroup.user_id, group=usergroup.group)
 

--- a/ata_api/main.py
+++ b/ata_api/main.py
@@ -38,13 +38,13 @@ def get_root(
 def get_prescription(
     response: Response,
     settings: AnnotatedSettings,
+    session: Annotated[Session, Depends(create_db_session)],
     site_name: Annotated[SiteName, Path(title="Site name")],
     user_id: Annotated[UUID, Path(title="Snowplow user ID")],
     wa: Annotated[int, Query(title="Weight of assignment to A", ge=0)] = 1,
     wb: Annotated[int, Query(title="Weight of assignment to B", ge=0)] = 1,
     wc: Annotated[int, Query(title="Weight of assignment to C", ge=0)] = 1,
     origin: AnnotatedOrigin = None,
-    session: Session = Depends(create_db_session),
 ) -> PrescriptionResponse:
     # Get group assignment. If it doesn't exist, create it.
     logger.info(f"Reading prescription for user {user_id} at site {site_name}")

--- a/ata_api/settings.py
+++ b/ata_api/settings.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 from typing import Optional
 
 from ata_db_models.helpers import Stage
@@ -7,12 +8,27 @@ from ata_api.monitoring.logging import logger
 
 
 class Settings(BaseSettings):
+    """
+    Settings for the AtA API, including but not limited to those set with
+    environment variables.
+    """
+
+    # If you want to use an environment variable, add it here.
     stage: Optional[Stage] = None
     cors_allowed_origins: set[HttpUrl] = set()
 
 
-settings = Settings()
-if len(settings.cors_allowed_origins) == 0:
-    logger.warning("CORS_ALLOWED_ORIGINS not set, defaulting to empty list")
-else:
-    logger.info(f"CORS_ALLOWED_ORIGINS set to {settings.cors_allowed_origins}")
+@lru_cache
+def get_settings(log: bool = False) -> Settings:
+    settings = Settings()
+
+    if log is True:
+        if len(settings.cors_allowed_origins) == 0:
+            logger.warning("CORS_ALLOWED_ORIGINS not set, defaulting to empty list")
+        else:
+            logger.info(f"CORS_ALLOWED_ORIGINS set to {settings.cors_allowed_origins}")
+
+    return settings
+
+
+settings = get_settings(log=True)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,16 +1,33 @@
-from typing import Generator, Tuple
+from collections.abc import Callable
+from contextlib import contextmanager
+from typing import Generator, Tuple, Any
 from uuid import UUID
 
 import pytest
 from ata_db_models.models import Group, SQLModel, UserGroup
 from fastapi import status
 from fastapi.testclient import TestClient
+from pydantic import HttpUrl
 
 from ata_api.db import engine, session_factory
 from ata_api.main import app
+from ata_api.settings import Settings, get_settings
 from ata_api.site import SiteName
 
 client = TestClient(app)
+
+
+@contextmanager
+def override_dependencies(key_value_pairs: list[tuple[Callable[..., Any], Callable[..., Any]]]) -> Generator[None, None, None]:
+    """
+    Fixture responsible for overriding dependencies for the duration of a test.
+    """
+    try:
+        for key, value in key_value_pairs:
+            app.dependency_overrides[key] = value
+        yield
+    finally:
+        app.dependency_overrides = {}
 
 
 @pytest.fixture(scope="function")
@@ -27,18 +44,52 @@ def create_and_drop_tables() -> Generator[None, None, None]:
     SQLModel.metadata.drop_all(engine)
 
 
+@pytest.fixture(scope="module")
+def allowed_origin() -> HttpUrl:
+    return "https://allowed.com"    # type: ignore
+
+
+@pytest.fixture(scope="module")
+def denied_origin() -> HttpUrl:
+    return "https://denied.com"   # type: ignore
+
+
 class TestRoot:
+    @pytest.fixture(scope="class")
+    def endpoint(self) -> str:
+        return "/"
+
     @pytest.mark.unit
-    def test_root(self) -> None:
-        response = client.get("/")
+    def test_root(self, endpoint: str) -> None:
+        response = client.get(endpoint)
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {"message": "This is the root endpoint for the AtA API."}
+
+    @pytest.mark.unit
+    def test_cors_allowed_origin(self, endpoint: str, allowed_origin: HttpUrl) -> None:
+        with override_dependencies([(get_settings, lambda: Settings(cors_allowed_origins={allowed_origin}))]):
+            response = client.get(endpoint, headers={"Origin": allowed_origin})
+            assert response.status_code == status.HTTP_200_OK
+            assert response.headers["access-control-allow-origin"] == allowed_origin
+            assert "Origin" in response.headers["vary"]
+
+    @pytest.mark.unit
+    def test_cors_denied_origin(self, endpoint: str, allowed_origin: HttpUrl, denied_origin: HttpUrl) -> None:
+        with override_dependencies([(get_settings, lambda: Settings(cors_allowed_origins={allowed_origin}))]):
+            response = client.get(endpoint, headers={"Origin": denied_origin})
+            assert response.status_code == status.HTTP_200_OK
+            assert "access-control-allow-origin" not in response.headers
+            assert "vary" not in response.headers or "Origin" not in response.headers["vary"]
 
 
 class TestPrescription:
     @pytest.fixture(scope="class")
     def user(self) -> Tuple[str, str]:
         return (SiteName.AFRO_LA, "3800ac11781a4cf2a6759bbaa9c0729b")
+
+    @pytest.fixture(scope="class")
+    def endpoint(self, user: tuple[str, str]) -> str:
+        return f"/prescription/{user[0]}/{user[1]}"
 
     @pytest.mark.unit
     def test_invalid_user_id(self, user: Tuple[str, str]) -> None:
@@ -53,12 +104,14 @@ class TestPrescription:
         assert "value is not a valid enumeration member" in response.json()["detail"][0]["msg"]
 
     @pytest.mark.integration
-    def test_user_missing(self, create_and_drop_tables: Generator[None, None, None], user: Tuple[str, str]) -> None:
+    def test_user_missing(
+        self, user: Tuple[str, str], endpoint: str, create_and_drop_tables: Generator[None, None, None]
+    ) -> None:
         """
         If a valid user (valid ID & site name) doesn't already exist, they
         should be created.
         """
-        response = client.get(f"/prescription/{'/'.join(user)}")
+        response = client.get(endpoint)
         assert response.status_code == status.HTTP_200_OK
 
         # Check returned data is of the right user
@@ -73,7 +126,9 @@ class TestPrescription:
             assert count == 1
 
     @pytest.mark.integration
-    def test_user_exists(self, create_and_drop_tables: Generator[None, None, None], user: Tuple[str, str]) -> None:
+    def test_user_exists(
+        self, user: Tuple[str, str], endpoint: str, create_and_drop_tables: Generator[None, None, None]
+    ) -> None:
         """
         If a valid user (valid ID & site name) already exists, they should
         simply be returned.
@@ -90,7 +145,7 @@ class TestPrescription:
             assert count == 1
 
         # Make endpoint call
-        response = client.get(f"/prescription/{'/'.join(user)}")
+        response = client.get(endpoint)
         assert response.status_code == status.HTTP_200_OK
 
         # Check returned data is of the right user
@@ -98,3 +153,27 @@ class TestPrescription:
         assert data["site_name"] == user[0]
         assert UUID(data["user_id"]) == UUID(user[1])
         assert data["group"] in {*Group}  # A, B or C
+
+    @pytest.mark.integration
+    def test_cors_allowed_origin(
+        self, endpoint: str, allowed_origin: HttpUrl, create_and_drop_tables: Generator[None, None, None]
+    ) -> None:
+        with override_dependencies([(get_settings, lambda: Settings(cors_allowed_origins={allowed_origin}))]):
+            response = client.get(endpoint, headers={"Origin": allowed_origin})
+            assert response.status_code == status.HTTP_200_OK
+            assert response.headers["access-control-allow-origin"] == allowed_origin
+            assert "Origin" in response.headers["vary"]
+
+    @pytest.mark.integration
+    def test_cors_denied_origin(
+        self,
+        endpoint: str,
+        allowed_origin: HttpUrl,
+        denied_origin: HttpUrl,
+        create_and_drop_tables: Generator[None, None, None],
+    ) -> None:
+        with override_dependencies([(get_settings, lambda: Settings(cors_allowed_origins={allowed_origin}))]):
+            response = client.get(endpoint, headers={"Origin": denied_origin})
+            assert response.status_code == status.HTTP_200_OK
+            assert "access-control-allow-origin" not in response.headers
+            assert "vary" not in response.headers or "Origin" not in response.headers["vary"]


### PR DESCRIPTION
## Description

Adds unit tests involving CORS to the root and prescription endpoints. Toward that end, change the CORS decorator to just a simple function that accepts `settings` as a FastAPI dependency.

## Testing
All tests passed.